### PR TITLE
Fix Consumer dispatch queue handler

### DIFF
--- a/sources/core/consumer.cpp
+++ b/sources/core/consumer.cpp
@@ -58,8 +58,10 @@ void
 consumer::dispatch_changed_handler(size_t size) {
   if (size >= m_max_concurrency) {
     dispatch_queue_full.store(true);
-    dispatch_queue_changed.notify_all();
+  } else {
+    dispatch_queue_full.store(false);
   }
+  dispatch_queue_changed.notify_all();
 }
 
 void


### PR DESCRIPTION
- When the queue is full (more messages than threads) the queue full flag
  was set to True but never reset. Which lead to a blocking state were
  messages are not read anymore.